### PR TITLE
[ add ] HS/Cleave queue display

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 * * Requires a plain instant melee ability to be on your action bars.
 * Added `/st offhand` command to toggle off showing offhand swing.
 * Added `/st range` command to toggle off showing range swing, wands only right now.
+* Added `/st hs` command to toggle mainhand HS/Cleave queue display. 
+* * Requires correct icon or macro named "cleave", "heroicstrike", "heroic strike", or "hs".
 ___
 
 Author: EinBaum


### PR DESCRIPTION
Added a setting to toggle Heroic Strike and Cleave queue display. The main-hand bar will change color when either is queued: yellow for Heroic Strike, green for Cleave, and white for Auto Attack. This can be toggled on or off with /st hs.